### PR TITLE
Reorganize cleanup step in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,6 +124,7 @@ jobs:
           fi
 
       - name: "Clean up filtered directory"
+        if: always()
         run: |
           echo "Removing temporary src-filtered directory..."
           rm -rf ./src-filtered

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,11 +53,6 @@ jobs:
             fi
           done
 
-      - name: "Clean up filtered directory"
-        run: |
-          echo "Removing temporary src-filtered directory..."
-          rm -rf ./src-filtered
-
       - name: "Make packages public"
         env:
           GITHUB_TOKEN: ${{ secrets.PACKAGE_PAT }}
@@ -127,3 +122,8 @@ jobs:
               git push origin "$branch"
               gh pr create --title "$message" --body "$message"
           fi
+
+      - name: "Clean up filtered directory"
+        run: |
+          echo "Removing temporary src-filtered directory..."
+          rm -rf ./src-filtered


### PR DESCRIPTION
Move the cleanup of the filtered directory to the end of the release workflow to ensure all necessary steps are completed before cleanup.